### PR TITLE
ID-6432: Remove redundant library (INTERNAL-COMMIT)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,8 +10,6 @@ RUN curl -H "Authorization: token ${GIT_PACKAGE_TOKEN}" -L -O \
   https://maven.pkg.github.com/felleslosninger/eidas-redis-lib/no/idporten/eidas/eidas-redis/${REDIS_LIB_VERSION}/eidas-redis-${REDIS_LIB_VERSION}.jar
 RUN curl -H "Authorization: token ${GIT_PACKAGE_TOKEN}" -L -O \
   https://maven.pkg.github.com/felleslosninger/eidas-redis-lib/no/idporten/eidas/eidas-redis-node/${REDIS_LIB_VERSION}/eidas-redis-node-${REDIS_LIB_VERSION}.jar
-RUN curl -H "Authorization: token ${GIT_PACKAGE_TOKEN}" -L -O \
-  https://maven.pkg.github.com/felleslosninger/eidas-redis-lib/no/idporten/eidas/eidas-redis-specific-communication/${REDIS_LIB_VERSION}/eidas-redis-specific-communication-${REDIS_LIB_VERSION}.jar
 
 # Logstash-logback-endcoder to enable JSON logging (needs jackson). Versions must match logback in connector pom.xml
 ARG LOG_LIB_VERSION=8.0


### PR DESCRIPTION

SAK:
ID-6432

Sjekklister:  
Eigar:

- [x] Vurdert Manual deploy
- [x] Vurdert "internal"
- [x] Avhengigheter til andre eidas komponenter avklart
- [x] Har kjørt opp lokalt med docker-compose og testet en innlogging via teknisk testklient
- [x] Husket at denne er basert på EU software, så kan ikke oppdateres helt ukritisk
- [x] Oppdatering/oppretting av regresjonstester er avklart/utført om relevant

Kodeles:

- [ ] Lesbar kode, nødvendige kommentarer
- [ ] Sak er godt nok forklart/dokumentert
- [ ] Løyser saka
- [ ] Risikovurdering ok
- [ ] Nødvendige unit-tester er på plass
- [ ] Har oppdatert readme 